### PR TITLE
Add ability to configure storage directory for quick notes

### DIFF
--- a/src/html/popup.template.html
+++ b/src/html/popup.template.html
@@ -121,6 +121,9 @@
                         <label for="token">Token</label>
                         <input type="password" id="token">
                         <span class="pure-form-message">The token is set in the environment variable SB_AUTH_TOKEN</span>
+                        <label for="directory">Directory</label>
+                        <input type="text" id="directory">
+                        <span class="pure-form-message">Directory in Silverbullet to store quick notes</span>
                     </fieldset>
                 </form>
 

--- a/src/js/popup.template.js
+++ b/src/js/popup.template.js
@@ -31,7 +31,8 @@ document.addEventListener("DOMContentLoaded", () => {
     saveButton.addEventListener("click", () => {
         const hostURL = document.getElementById("hostURL").value;
         const token = document.getElementById("token").value;
-        <%= runTime %>.storage.sync.set({ "hostURL": hostURL, "token": token }, () => {
+        const directory = document.getElementById('directory').value;
+        <%= runTime %>.storage.sync.set({ "hostURL": hostURL, "token": token, "directory": directory }, () => {
             hideConfigure();
             showCapture();
         });
@@ -61,8 +62,11 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     displayTitle();
     //Prompt to provide credentials if they are missing
-    <%= runTime %>.storage.sync.get(["hostURL", "token"]).then(items => {
-        if(items === null || items.hostURL === null || items.hostURL === '' || items.token === null || items.token === '') {
+    <%= runTime %>.storage.sync.get(["hostURL", "token", "directory"]).then(items => {
+        if(items === null || items.hostURL === null || items.hostURL === '' 
+          || items.token === null || items.token === '' 
+          || items.directory === null || items.directory === '') 
+        {
             hideCapture();
             showConfigure();
         }
@@ -78,9 +82,10 @@ function showConfigure() {
         configure.classList.remove("hidden");
     }
     //Get the hostURL and token from storage
-    <%= runTime %>.storage.sync.get(["hostURL", "token"], (items) => {
+    <%= runTime %>.storage.sync.get(["hostURL", "token", "directory"], (items) => {
         document.getElementById('hostURL').value = items?.hostURL || '';
         document.getElementById('token').value = items?.token || '';
+        document.getElementById('directory').value = items.directory || '';
     });
 }
 

--- a/src/js/popup.template.js
+++ b/src/js/popup.template.js
@@ -85,7 +85,7 @@ function showConfigure() {
     <%= runTime %>.storage.sync.get(["hostURL", "token", "directory"], (items) => {
         document.getElementById('hostURL').value = items?.hostURL || '';
         document.getElementById('token').value = items?.token || '';
-        document.getElementById('directory').value = items.directory || '';
+        document.getElementById('directory').value = items.directory || 'Inbox';
     });
 }
 

--- a/src/js/service-worker.template.js
+++ b/src/js/service-worker.template.js
@@ -131,8 +131,8 @@ async function hasDocument() {
 <% } %>
 /* Send the markdown to the Silverbullet endpoint */
 function sendCaptureToEndpoint(markdown, title) {
-    <%= runTime %>.storage.sync.get(["hostURL", "token"], (items) => {
-        const link = items.hostURL + '/Inbox/' + encodeURI(title);
+    <%= runTime %>.storage.sync.get(["hostURL", "token", "directory"], (items) => {
+        const link = items.hostURL + '/' + items.directory + '/' + encodeURI(title);
         const endpoint = link + '.md';
         const requestOptions = {
             method: 'PUT',


### PR DESCRIPTION
Normally I store my quick notes in a directory called *Capture* and not *Inbox*. So it would be cool to be able to set this to something other than *Inbox* if needed.