### PR TITLE
Add page title of tab to text

### DIFF
--- a/src/js/service-worker.template.js
+++ b/src/js/service-worker.template.js
@@ -76,7 +76,7 @@ async function getTitleFromTab(tabId) {
 }
 
 /* Use an offscreen document to parse the captured DOM */
-async function sendMessageToOffscreenDocument(type, data, url, title, tags, saveMetadataAsFrontmatter) {
+async function sendMessageToOffscreenDocument(type, data, url, pageTitle, title, tags, saveMetadataAsFrontmatter) {
     if (!(await hasDocument())) {
         await chrome.offscreen.createDocument({
             url: OFFSCREEN_DOCUMENT_PATH,
@@ -89,6 +89,7 @@ async function sendMessageToOffscreenDocument(type, data, url, title, tags, save
         target: 'offscreen',
         data,
         url,
+        pageTitle,
         title,
         tags,
         saveMetadataAsFrontmatter
@@ -166,12 +167,13 @@ async function getTitleFromTab(tabId) {
 }
 
 /* Use an offscreen document to parse the captured DOM */
-function sendMessageToOffscreenDocument(type, data, url, title, tags, saveMetadataAsFrontmatter) {
+function sendMessageToOffscreenDocument(type, data, url, pageTitle, title, tags, saveMetadataAsFrontmatter) {
     browser.runtime.sendMessage({
         type,
         target: 'offscreen',
         data,
         url,
+        pageTitle,
         title,
         tags,
         saveMetadataAsFrontmatter
@@ -206,11 +208,14 @@ async function captureTab(title, tags, appendPageTitle, saveMetadataAsFrontmatte
     let queryOptions = { active: true, lastFocusedWindow: true };
     let [tab] = await <%= runTime %>.tabs.query(queryOptions);
     const url = tab.url;
+
+    //Get the title of the web page from the tab
+    let pageTitle = await getTitleFromTab(tab.id);
+
     if(appendPageTitle) {
-        //Get the title of the web page from the tab
-        let pageTitle = await getTitleFromTab(tab.id);
         title += ' (' + pageTitle + ')';
     }
+
     const invalidCharactersRegex = /[^a-zA-Z0-9\-_\s\(\):]/g;
     title = title.replace(invalidCharactersRegex,'_');
     <%= runTime %>.storage.sync.get(["maxTitleLength"], (items) => {
@@ -225,6 +230,7 @@ async function captureTab(title, tags, appendPageTitle, saveMetadataAsFrontmatte
             'convert-to-markdown',
             text,
             url,
+            pageTitle,
             title,
             tags,
             saveMetadataAsFrontmatter


### PR DESCRIPTION
I personally prefer to have the page (tab) title in the body of the clipped document (and not filename) so this PR adds that to the body as well as the frontmatter if enabled.